### PR TITLE
Fix: Handle non JSON text

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -64,7 +64,7 @@ function start (config) {
         return {
           level: 30,
           wasRaw: true,
-          time: `${Date.now()}`,
+          time: Date.now(),
           tags: ['info'],
           data: {
             msg: line

--- a/lib/index.js
+++ b/lib/index.js
@@ -56,6 +56,23 @@ function start (config) {
     }
   }
 
+  function safeParse(line) {
+    try {
+      return JSON.parse(line);
+    }
+    catch (err){
+        return {
+          level: 30,
+          wasRaw: true,
+          time: `${(new Date()).getTime()/1000|0}`,
+          tags: ['info'],
+          data: {
+            msg: line
+          }
+        }
+    }
+  }
+
   // transform stream
   const myTransport = Through.obj(function (data, enc, cb) {
     let result
@@ -76,7 +93,7 @@ function start (config) {
   })
 
   // get stdin and pump through Split to parse JSON, and send to transport.
-  Pump(process.stdin, Split(JSON.parse), myTransport)
+  Pump(process.stdin, Split(safeParse), myTransport)
 
   // stdin finishes, close the output stream.
   process.stdin.on('end', () => shutdown('stdin ended'))

--- a/lib/index.js
+++ b/lib/index.js
@@ -64,7 +64,7 @@ function start (config) {
         return {
           level: 30,
           wasRaw: true,
-          time: `${(new Date()).getTime()/1000|0}`,
+          time: `${Date.now()}`,
           tags: ['info'],
           data: {
             msg: line

--- a/lib/index.js
+++ b/lib/index.js
@@ -66,9 +66,7 @@ function start (config) {
           wasRaw: true,
           time: Date.now(),
           tags: ['info'],
-          data: {
-            msg: line
-          }
+          data: line
         }
     }
   }

--- a/tests/unit/index.test.js
+++ b/tests/unit/index.test.js
@@ -125,7 +125,7 @@ Tape('start with true filter with write to file with non-JSON', (t) => {
 
     t.true(writeStub.calledOnce, 'Write stub called')
     const arg = JSON.parse(writeStub.getCall(0).args[0]);
-    t.equals(arg.data.msg, 'msg', 'write stub called with json')
+    t.equals(arg.data, 'msg', 'write stub called with json')
     t.equals(arg.level, 30, 'write stub called with json at level 30')
     t.equals(arg.tags[0], 'info', 'write stub called with json with tags set to info');
     t.true(arg.wasRaw, 'wasRaw was set to true')

--- a/tests/unit/index.test.js
+++ b/tests/unit/index.test.js
@@ -124,7 +124,7 @@ Tape('start with true filter with write to file with non-JSON', (t) => {
     t.equals(stdout.length, 0, 'zero lines')
 
     t.true(writeStub.calledOnce, 'Write stub called')
-    arg = JSON.parse(writeStub.getCall(0).args[0]);
+    const arg = JSON.parse(writeStub.getCall(0).args[0]);
     t.equals(arg.data.msg, 'msg', 'write stub called with json')
     t.equals(arg.level, 30, 'write stub called with json at level 30')
     t.equals(arg.tags[0], 'info', 'write stub called with json with tags set to info');

--- a/tests/unit/index.test.js
+++ b/tests/unit/index.test.js
@@ -96,6 +96,43 @@ Tape('start with true filter with write to file', (t) => {
   })
 })
 
+Tape('start with true filter with write to file with non-JSON', (t) => {
+  beforeEach()
+  t.plan(7)
+
+  const writeStub = Sinon.stub()
+  const endStub = Sinon.stub()
+  function rfs () {
+    this.write = writeStub
+    this.end = endStub
+  }
+  Mock('rotating-file-stream', rfs)
+
+  const stdin = StdInMock.stdin()
+  StdOutMock.use({ stdout: true, stderr: true, print: true })
+
+  const config = { filter () { return true }, output: { path: 'test.log', options: {} }, exit: false }
+  const { start } = require(requirePath)
+  start(config)
+
+  stdin.send(Buffer.from('msg', 'utf8'))
+  stdin.send(null)
+  setImmediate(() => {
+    StdOutMock.restore()
+    stdin.restore()
+    const { stdout } = StdOutMock.flush()
+    t.equals(stdout.length, 0, 'zero lines')
+
+    t.true(writeStub.calledOnce, 'Write stub called')
+    arg = JSON.parse(writeStub.getCall(0).args[0]);
+    t.equals(arg.data.msg, 'msg', 'write stub called with json')
+    t.equals(arg.level, 30, 'write stub called with json at level 30')
+    t.equals(arg.tags[0], 'info', 'write stub called with json with tags set to info');
+    t.true(arg.wasRaw, 'wasRaw was set to true')
+    t.true(endStub.calledOnce, 'end called')
+  })
+})
+
 Tape('start with true filter with write to file (no output options)', (t) => {
   beforeEach()
   t.plan(3)


### PR DESCRIPTION
Previous to this PR if we recieved text that was not json, we would
throw an exception and stop logging. This could happen if hapi has a
console.log in it for instance.

This change catches the JSON.Parse exception, wraps the raw text in a
JSON object, and sets a wasRaw flag that can be filtered against.