### PR TITLE
Other: Fix standard linting

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -56,18 +56,17 @@ function start (config) {
     }
   }
 
-  function safeParse(line) {
+  function safeParse (line) {
     try {
-      return JSON.parse(line);
-    }
-    catch (err){
-        return {
-          level: 30,
-          wasRaw: true,
-          time: Date.now(),
-          tags: ['info'],
-          data: line
-        }
+      return JSON.parse(line)
+    } catch (err) {
+      return {
+        level: 30,
+        wasRaw: true,
+        time: Date.now(),
+        tags: ['info'],
+        data: line
+      }
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "scripts": {
     "test": "npm run lint && npm run nyc",
-    "lint": "standard ./lib",
+    "lint": "standard",
     "tape": "tape ./tests/**/*.test.js | tap-spec",
     "nyc": "nyc --reporter=text --reporter=text-summary --reporter=html npm run tape",
     "postnyc": "nyc check-coverage --statements 100 --branches 100 --functions 100 --lines 100"

--- a/tests/unit/index.test.js
+++ b/tests/unit/index.test.js
@@ -124,10 +124,10 @@ Tape('start with true filter with write to file with non-JSON', (t) => {
     t.equals(stdout.length, 0, 'zero lines')
 
     t.true(writeStub.calledOnce, 'Write stub called')
-    const arg = JSON.parse(writeStub.getCall(0).args[0]);
+    const arg = JSON.parse(writeStub.getCall(0).args[0])
     t.equals(arg.data, 'msg', 'write stub called with json')
     t.equals(arg.level, 30, 'write stub called with json at level 30')
-    t.equals(arg.tags[0], 'info', 'write stub called with json with tags set to info');
+    t.equals(arg.tags[0], 'info', 'write stub called with json with tags set to info')
     t.true(arg.wasRaw, 'wasRaw was set to true')
     t.true(endStub.calledOnce, 'end called')
   })


### PR DESCRIPTION
Noticed the `standard ./lib` lint command is not working, instead we can simply say `standard` which defaults to patterns `**/*.js, **/*.jsx`

Also fixed the existing linting issues.